### PR TITLE
Restructure enable/disable notification and write command implementations

### DIFF
--- a/buruberi-core/buruberi-core.iml
+++ b/buruberi-core/buruberi-core.iml
@@ -67,29 +67,19 @@
       <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/build/.DS_Store" />
       <excludeFolder url="file://$MODULE_DIR$/build/docs" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/annotations" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/coverage-instrumented-classes" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dex" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dex-cache" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jacoco" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/javaResources" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/libs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/lint" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/ndk" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/pre-dexed" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/proguard" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/mockable-android-23.jar" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
       <excludeFolder url="file://$MODULE_DIR$/build/libs" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
-      <excludeFolder url="file://$MODULE_DIR$/build/publications" />
       <excludeFolder url="file://$MODULE_DIR$/build/reports" />
       <excludeFolder url="file://$MODULE_DIR$/build/test-results" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
@@ -100,8 +90,8 @@
     <orderEntry type="library" exported="" scope="TEST" name="ant-1.8.0" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="accessibility-test-framework-1.0" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="hamcrest-library-1.3" level="project" />
-    <orderEntry type="library" exported="" scope="TEST" name="asm-commons-5.0.1" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="ant-launcher-1.8.0" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="asm-commons-5.0.1" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="asm-5.0.1" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="shadows-core-3.0" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="asm-util-5.0.1" level="project" />
@@ -115,11 +105,11 @@
     <orderEntry type="library" exported="" scope="TEST" name="robolectric-annotations-3.0" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="asm-tree-5.0.1" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="sqlite4java-0.282" level="project" />
-    <orderEntry type="library" exported="" scope="TEST" name="robolectric-utils-3.0" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="asm-analysis-5.0.1" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="robolectric-utils-3.0" level="project" />
     <orderEntry type="library" exported="" name="rxjava-1.0.14" level="project" />
-    <orderEntry type="library" exported="" scope="TEST" name="vtd-xml-2.11" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="hamcrest-core-1.3" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="vtd-xml-2.11" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="junit-4.12" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="robolectric-3.0" level="project" />
     <orderEntry type="module" module-name="buruberi-testing" exported="" scope="TEST" />

--- a/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/BluetoothStack.java
+++ b/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/BluetoothStack.java
@@ -17,7 +17,6 @@ package is.hello.buruberi.bluetooth.stacks;
 
 import android.Manifest;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.support.annotation.RequiresPermission;
 
 import java.util.List;
@@ -109,14 +108,6 @@ public interface BluetoothStack {
 
 
     /**
-     * Returns a boolean indicating whether or not a given error
-     * is fatal for the {@code BluetoothStack} implementation, and
-     * the client code should disconnect and perform a rediscovery.
-     */
-    boolean errorRequiresReconnect(@Nullable Throwable e);
-
-
-    /**
      * Returns the logger facade associated with the {@code BluetoothStack}.
      */
     @NonNull LoggerFacade getLogger();
@@ -124,12 +115,17 @@ public interface BluetoothStack {
 
     /**
      * Returns the level of support the stack has for the current device.
+     *
+     * @deprecated Device support depends on factors outside of the scope of the Buruberi library,
+     *             as such, this method is deprecated with no replacement.
      */
+    @Deprecated
     SupportLevel getDeviceSupportLevel();
 
     /**
      * Describes the level of support the current device has in the implementation.
      */
+    @Deprecated
     enum SupportLevel {
         /**
          * The device is unsupported, one or more core operations are known to fail.

--- a/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/android/GattDispatcher.java
+++ b/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/android/GattDispatcher.java
@@ -62,22 +62,21 @@ class GattDispatcher extends BluetoothGattCallback {
         connectionStateListeners.remove(changeHandler);
     }
 
-    Action0 addDisconnectListener(@NonNull Action0 disconnectListener) {
-        disconnectListeners.add(disconnectListener);
-        return disconnectListener;
-    }
-
-    <T> Action0 addTimeoutDisconnectListener(final @NonNull Subscriber<T> subscriber, final @NonNull OperationTimeout timeout) {
-        return addDisconnectListener(new Action0() {
+    <T> Action0 addTimeoutDisconnectListener(final @NonNull Subscriber<T> subscriber,
+                                             final @NonNull OperationTimeout timeout) {
+        final Action0 onDisconnect = new Action0() {
             @Override
             public void call() {
-                logger.info(GattPeripheral.LOG_TAG, "onDisconnectListener(" + subscriber.hashCode() + ")");
+                logger.info(GattPeripheral.LOG_TAG,
+                            "onDisconnectListener(" + subscriber.hashCode() + ")");
 
                 timeout.unschedule();
 
                 subscriber.onError(new LostConnectionException());
             }
-        });
+        };
+        disconnectListeners.add(onDisconnect);
+        return onDisconnect;
     }
 
     void removeDisconnectListener(@NonNull Action0 disconnectListener) {
@@ -94,7 +93,7 @@ class GattDispatcher extends BluetoothGattCallback {
                 GattDispatcher.this.onCharacteristicWrite = null;
                 GattDispatcher.this.onDescriptorWrite = null;
 
-                for (Action0 onDisconnect : disconnectListeners) {
+                for (final Action0 onDisconnect : disconnectListeners) {
                     onDisconnect.call();
                 }
                 disconnectListeners.clear();
@@ -109,7 +108,8 @@ class GattDispatcher extends BluetoothGattCallback {
     @Override
     public void onConnectionStateChange(final BluetoothGatt gatt, final int status, final int newState) {
         super.onConnectionStateChange(gatt, status, newState);
-        logger.info(GattPeripheral.LOG_TAG, "onConnectionStateChange('" + gatt + "', " + status + ", " + newState + ")");
+        logger.info(GattPeripheral.LOG_TAG, "onConnectionStateChange('" + gatt + "', " +
+                status + ", " + newState + ")");
 
         dispatcher.post(new Runnable() {
             @Override
@@ -147,10 +147,11 @@ class GattDispatcher extends BluetoothGattCallback {
     }
 
     @Override
-    public void onCharacteristicRead(final BluetoothGatt gatt, final BluetoothGattCharacteristic characteristic, final int status) {
-        super.onCharacteristicRead(gatt, characteristic, status);
-
-        logger.info(GattPeripheral.LOG_TAG, "onCharacteristicRead('" + gatt + "', " + characteristic + ", " + status + ")");
+    public void onCharacteristicRead(final BluetoothGatt gatt,
+                                     final BluetoothGattCharacteristic characteristic,
+                                     final int status) {
+        logger.info(GattPeripheral.LOG_TAG, "onCharacteristicRead('" + gatt + "', " +
+                characteristic + ", " + status + ")");
 
         dispatcher.post(new Runnable() {
             @Override
@@ -164,10 +165,11 @@ class GattDispatcher extends BluetoothGattCallback {
     }
 
     @Override
-    public void onCharacteristicWrite(final BluetoothGatt gatt, final BluetoothGattCharacteristic characteristic, final int status) {
-        super.onCharacteristicWrite(gatt, characteristic, status);
-
-        logger.info(GattPeripheral.LOG_TAG, "onCharacteristicWrite('" + gatt + "', " + characteristic + ", " + status + ")");
+    public void onCharacteristicWrite(final BluetoothGatt gatt,
+                                      final BluetoothGattCharacteristic characteristic,
+                                      final int status) {
+        logger.info(GattPeripheral.LOG_TAG, "onCharacteristicWrite('" + gatt + "', " +
+                characteristic + ", " + status + ")");
 
         dispatcher.post(new Runnable() {
             @Override
@@ -182,10 +184,10 @@ class GattDispatcher extends BluetoothGattCallback {
     }
 
     @Override
-    public void onCharacteristicChanged(final BluetoothGatt gatt, final BluetoothGattCharacteristic characteristic) {
-        super.onCharacteristicChanged(gatt, characteristic);
-
-        logger.info(GattPeripheral.LOG_TAG, "onCharacteristicChanged('" + gatt + "', " + characteristic + ", " + ")");
+    public void onCharacteristicChanged(final BluetoothGatt gatt,
+                                        final BluetoothGattCharacteristic characteristic) {
+        logger.info(GattPeripheral.LOG_TAG, "onCharacteristicChanged('" + gatt + "', " +
+                characteristic + ", " + ")");
 
         dispatcher.post(new Runnable() {
             @Override
@@ -199,9 +201,9 @@ class GattDispatcher extends BluetoothGattCallback {
     }
 
     @Override
-    public void onDescriptorWrite(final BluetoothGatt gatt, final BluetoothGattDescriptor descriptor, final int status) {
-        super.onDescriptorWrite(gatt, descriptor, status);
-
+    public void onDescriptorWrite(final BluetoothGatt gatt,
+                                  final BluetoothGattDescriptor descriptor,
+                                  final int status) {
         logger.info(GattPeripheral.LOG_TAG, "onDescriptorWrite('" + gatt + "', " + descriptor + ", " + ")");
 
         dispatcher.post(new Runnable() {

--- a/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/android/HighPowerPeripheralScanner.java
+++ b/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/android/HighPowerPeripheralScanner.java
@@ -61,7 +61,7 @@ class HighPowerPeripheralScanner extends BroadcastReceiver implements Observable
     HighPowerPeripheralScanner(@NonNull NativeBluetoothStack stack, boolean saveResults) {
         this.context = stack.applicationContext;
         this.adapter = stack.getAdapter();
-        this.worker = stack.scheduler.createWorker();
+        this.worker = stack.getScheduler().createWorker();
         this.logger = stack.getLogger();
 
         if (saveResults) {

--- a/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/android/NativeGattCharacteristic.java
+++ b/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/android/NativeGattCharacteristic.java
@@ -1,0 +1,121 @@
+package is.hello.buruberi.bluetooth.stacks.android;
+
+import android.bluetooth.BluetoothGattCharacteristic;
+import android.bluetooth.BluetoothGattDescriptor;
+import android.support.annotation.NonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import is.hello.buruberi.bluetooth.stacks.GattCharacteristic;
+import is.hello.buruberi.bluetooth.stacks.GattPeripheral;
+import is.hello.buruberi.bluetooth.stacks.GattService;
+import is.hello.buruberi.bluetooth.stacks.OperationTimeout;
+import rx.Observable;
+
+class NativeGattCharacteristic implements GattCharacteristic {
+    private final BluetoothGattCharacteristic nativeCharacteristic;
+    private final NativeGattService service;
+    private final NativeGattPeripheral peripheral;
+
+    NativeGattCharacteristic(@NonNull BluetoothGattCharacteristic nativeCharacteristic,
+                             @NonNull NativeGattService service,
+                             @NonNull NativeGattPeripheral peripheral) {
+        this.nativeCharacteristic = nativeCharacteristic;
+        this.service = service;
+        this.peripheral = peripheral;
+    }
+
+    @Override
+    public UUID getUuid() {
+        return nativeCharacteristic.getUuid();
+    }
+
+    @Override
+    @Properties
+    public int getProperties() {
+        final @Properties int properties = nativeCharacteristic.getProperties();
+        return properties;
+    }
+
+    @Override
+    @Permissions
+    public int getPermissions() {
+        final @Permissions int permissions = nativeCharacteristic.getPermissions();
+        return permissions;
+    }
+
+    @NonNull
+    @Override
+    public GattService getService() {
+        return service;
+    }
+
+    @NonNull
+    @Override
+    public List<UUID> getDescriptors() {
+        final List<UUID> identifiers = new ArrayList<>();
+        for (final BluetoothGattDescriptor descriptor : nativeCharacteristic.getDescriptors()) {
+            identifiers.add(descriptor.getUuid());
+        }
+        return identifiers;
+    }
+
+    @Permissions
+    @Override
+    public int getDescriptorPermissions(@NonNull UUID identifier) {
+        final BluetoothGattDescriptor descriptor = nativeCharacteristic.getDescriptor(identifier);
+        if (descriptor != null) {
+            final @Permissions int permissions = descriptor.getPermissions();
+            return permissions;
+        } else {
+            return PERMISSION_NULL;
+        }
+    }
+
+    @NonNull
+    @Override
+    public Observable<UUID> enableNotification(@NonNull UUID descriptor,
+                                               @NonNull OperationTimeout timeout) {
+        // TODO: Re-implement this operation in terms of new API.
+
+        return peripheral.enableNotification(getService(),
+                                             getUuid(),
+                                             descriptor,
+                                             timeout);
+    }
+
+    @NonNull
+    @Override
+    public Observable<UUID> disableNotification(@NonNull UUID descriptor,
+                                                @NonNull OperationTimeout timeout) {
+        // TODO: Re-implement this operation in terms of new API.
+
+        return peripheral.disableNotification(getService(),
+                                              getUuid(),
+                                              descriptor,
+                                              timeout);
+    }
+
+    @NonNull
+    @Override
+    public Observable<Void> write(@NonNull GattPeripheral.WriteType writeType,
+                                  @NonNull byte[] payload,
+                                  @NonNull OperationTimeout timeout) {
+        // TODO: Re-implement this operation in terms of new API.
+
+        return peripheral.writeCommand(getService(),
+                                       getUuid(),
+                                       writeType,
+                                       payload,
+                                       timeout);
+    }
+
+    @Override
+    public String toString() {
+        return "NativeCharacteristic{" +
+                "uuid=" + getUuid() +
+                '}';
+    }
+}

--- a/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/android/NativeGattCharacteristic.java
+++ b/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/android/NativeGattCharacteristic.java
@@ -1,5 +1,6 @@
 package is.hello.buruberi.bluetooth.stacks.android;
 
+import android.bluetooth.BluetoothGatt;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothGattDescriptor;
 import android.support.annotation.NonNull;
@@ -8,16 +9,26 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import is.hello.buruberi.bluetooth.errors.ConnectionStateException;
+import is.hello.buruberi.bluetooth.errors.GattException;
+import is.hello.buruberi.bluetooth.errors.OperationTimeoutException;
 import is.hello.buruberi.bluetooth.stacks.GattCharacteristic;
 import is.hello.buruberi.bluetooth.stacks.GattPeripheral;
 import is.hello.buruberi.bluetooth.stacks.GattService;
 import is.hello.buruberi.bluetooth.stacks.OperationTimeout;
+import is.hello.buruberi.bluetooth.stacks.util.LoggerFacade;
 import rx.Observable;
+import rx.Subscriber;
+import rx.functions.Action0;
+import rx.functions.Action3;
 
 class NativeGattCharacteristic implements GattCharacteristic {
     private final BluetoothGattCharacteristic nativeCharacteristic;
     private final NativeGattService service;
     private final NativeGattPeripheral peripheral;
+
+    private final LoggerFacade logger;
+    private final GattDispatcher gattDispatcher;
 
     NativeGattCharacteristic(@NonNull BluetoothGattCharacteristic nativeCharacteristic,
                              @NonNull NativeGattService service,
@@ -25,6 +36,9 @@ class NativeGattCharacteristic implements GattCharacteristic {
         this.nativeCharacteristic = nativeCharacteristic;
         this.service = service;
         this.peripheral = peripheral;
+
+        this.logger = peripheral.getStack().getLogger();
+        this.gattDispatcher = peripheral.gattDispatcher;
     }
 
     @Override
@@ -100,16 +114,65 @@ class NativeGattCharacteristic implements GattCharacteristic {
 
     @NonNull
     @Override
-    public Observable<Void> write(@NonNull GattPeripheral.WriteType writeType,
-                                  @NonNull byte[] payload,
-                                  @NonNull OperationTimeout timeout) {
-        // TODO: Re-implement this operation in terms of new API.
+    public Observable<Void> write(@NonNull final GattPeripheral.WriteType writeType,
+                                  @NonNull final byte[] payload,
+                                  @NonNull final OperationTimeout timeout) {
+        if (payload.length > GattPeripheral.PacketHandler.PACKET_LENGTH) {
+            return Observable.error(new IllegalArgumentException("Payload length " + payload.length +
+                                                                         " greater than " + GattPeripheral.PacketHandler.PACKET_LENGTH));
+        }
 
-        return peripheral.writeCommand(getService(),
-                                       getUuid(),
-                                       writeType,
-                                       payload,
-                                       timeout);
+        return peripheral.createObservable(new Observable.OnSubscribe<Void>() {
+            @Override
+            public void call(final Subscriber<? super Void> subscriber) {
+                if (peripheral.getConnectionStatus() != GattPeripheral.STATUS_CONNECTED ||
+                        peripheral.gatt == null) {
+                    subscriber.onError(new ConnectionStateException());
+                    return;
+                }
+
+                final Action0 onDisconnect = gattDispatcher.addTimeoutDisconnectListener(subscriber,
+                                                                                         timeout);
+                peripheral.setupTimeout(OperationTimeoutException.Operation.ENABLE_NOTIFICATION,
+                                        timeout, subscriber, onDisconnect);
+
+                gattDispatcher.onCharacteristicWrite = new Action3<BluetoothGatt, BluetoothGattCharacteristic, Integer>() {
+                    @Override
+                    public void call(BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, Integer status) {
+                        timeout.unschedule();
+
+                        if (status != BluetoothGatt.GATT_SUCCESS) {
+                            logger.error(GattPeripheral.LOG_TAG, "Could not write command " +
+                                    getUuid() + ", " + GattException.statusToString(status), null);
+                            subscriber.onError(new GattException(status,
+                                                                 GattException.Operation.WRITE_COMMAND));
+                        } else {
+                            subscriber.onNext(null);
+                            subscriber.onCompleted();
+                        }
+
+                        gattDispatcher.removeDisconnectListener(onDisconnect);
+                        gattDispatcher.onCharacteristicWrite = null;
+                    }
+                };
+
+                final BluetoothGattCharacteristic characteristic =
+                        service.wrappedService.getCharacteristic(getUuid());
+                // Looks like write type might need to be specified for some phones. See
+                // <http://stackoverflow.com/questions/25888817/android-bluetooth-status-133-in-oncharacteristicwrite>
+                characteristic.setWriteType(writeType.value);
+                characteristic.setValue(payload);
+                if (peripheral.gatt.writeCharacteristic(characteristic)) {
+                    timeout.schedule();
+                } else {
+                    gattDispatcher.removeDisconnectListener(onDisconnect);
+                    gattDispatcher.onCharacteristicWrite = null;
+
+                    subscriber.onError(new GattException(BluetoothGatt.GATT_WRITE_NOT_PERMITTED,
+                                                         GattException.Operation.WRITE_COMMAND));
+                }
+            }
+        });
     }
 
     @Override

--- a/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/android/NativeGattPeripheral.java
+++ b/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/android/NativeGattPeripheral.java
@@ -284,7 +284,7 @@ public class NativeGattPeripheral implements GattPeripheral {
                         disconnectForwarder.setEnabled(true);
                         subscriber.onError(new OperationTimeoutException(OperationTimeoutException.Operation.CONNECT));
                     }
-                }, stack.scheduler);
+                }, stack.getScheduler());
 
                 logger.info(LOG_TAG, "Connecting " + NativeGattPeripheral.this.toString());
 
@@ -440,7 +440,7 @@ public class NativeGattPeripheral implements GattPeripheral {
 
                 timeout.unschedule();
             }
-        }, stack.scheduler);
+        }, stack.getScheduler());
     }
 
     //endregion
@@ -452,7 +452,7 @@ public class NativeGattPeripheral implements GattPeripheral {
     private Observable<Intent> createBondReceiver() {
         return Rx.fromBroadcast(stack.applicationContext,
                                 new IntentFilter(BluetoothDevice.ACTION_BOND_STATE_CHANGED))
-                 .subscribeOn(stack.scheduler)
+                 .subscribeOn(stack.getScheduler())
                  .filter(new Func1<Intent, Boolean>() {
                      @Override
                      public Boolean call(Intent intent) {

--- a/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/android/NativeGattService.java
+++ b/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/android/NativeGattService.java
@@ -29,7 +29,7 @@ import is.hello.buruberi.bluetooth.stacks.GattCharacteristic;
 import is.hello.buruberi.bluetooth.stacks.GattService;
 
 public final class NativeGattService implements GattService {
-    final BluetoothGattService wrappedService;
+    /*package*/ final BluetoothGattService wrappedService;
     private final NativeGattPeripheral peripheral;
     private final Map<UUID, NativeGattCharacteristic> characteristics = new HashMap<>();
 

--- a/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/android/NativeGattService.java
+++ b/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/android/NativeGattService.java
@@ -16,7 +16,6 @@
 package is.hello.buruberi.bluetooth.stacks.android;
 
 import android.bluetooth.BluetoothGattCharacteristic;
-import android.bluetooth.BluetoothGattDescriptor;
 import android.bluetooth.BluetoothGattService;
 import android.support.annotation.NonNull;
 
@@ -27,18 +26,16 @@ import java.util.Map;
 import java.util.UUID;
 
 import is.hello.buruberi.bluetooth.stacks.GattCharacteristic;
-import is.hello.buruberi.bluetooth.stacks.GattPeripheral;
 import is.hello.buruberi.bluetooth.stacks.GattService;
-import is.hello.buruberi.bluetooth.stacks.OperationTimeout;
-import rx.Observable;
 
 public final class NativeGattService implements GattService {
-    final @NonNull BluetoothGattService service;
-    final @NonNull NativeGattPeripheral peripheral;
+    final BluetoothGattService service;
+    private final NativeGattPeripheral peripheral;
+    private final Map<UUID, NativeGattCharacteristic> characteristics = new HashMap<>();
 
 
     static @NonNull Map<UUID, GattService> wrap(@NonNull List<BluetoothGattService> services,
-                                                      @NonNull NativeGattPeripheral peripheral) {
+                                                @NonNull NativeGattPeripheral peripheral) {
         final Map<UUID, GattService> peripheralServices = new HashMap<>();
 
         for (final BluetoothGattService nativeService : services) {
@@ -79,12 +76,15 @@ public final class NativeGattService implements GattService {
 
     @Override
     public GattCharacteristic getCharacteristic(@NonNull UUID identifier) {
-        final BluetoothGattCharacteristic characteristic = service.getCharacteristic(identifier);
-        if (characteristic != null) {
-            return new NativeGattCharacteristic(characteristic);
-        } else {
-            return null;
+        NativeGattCharacteristic nativeCharacteristic = characteristics.get(identifier);
+        if (nativeCharacteristic == null) {
+            final BluetoothGattCharacteristic characteristic = service.getCharacteristic(identifier);
+            if (characteristic != null) {
+                nativeCharacteristic = new NativeGattCharacteristic(characteristic, this, peripheral);
+                characteristics.put(identifier, nativeCharacteristic);
+            }
         }
+        return nativeCharacteristic;
     }
 
 
@@ -93,8 +93,7 @@ public final class NativeGattService implements GattService {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        NativeGattService that = (NativeGattService) o;
-
+        final NativeGattService that = (NativeGattService) o;
         return service.equals(that.service);
     }
 
@@ -109,106 +108,5 @@ public final class NativeGattService implements GattService {
         return "AndroidPeripheralService{" +
                 "service=" + service +
                 '}';
-    }
-
-
-    class NativeGattCharacteristic implements GattCharacteristic {
-        private final BluetoothGattCharacteristic nativeCharacteristic;
-
-        NativeGattCharacteristic(@NonNull BluetoothGattCharacteristic nativeCharacteristic) {
-            this.nativeCharacteristic = nativeCharacteristic;
-        }
-
-        @Override
-        public UUID getUuid() {
-            return nativeCharacteristic.getUuid();
-        }
-
-        @Override
-        @Properties
-        public int getProperties() {
-            final @Properties int properties = nativeCharacteristic.getProperties();
-            return properties;
-        }
-
-        @Override
-        @Permissions
-        public int getPermissions() {
-            final @Permissions int permissions = nativeCharacteristic.getPermissions();
-            return permissions;
-        }
-
-        @NonNull
-        @Override
-        public GattService getService() {
-            return NativeGattService.this;
-        }
-
-        @NonNull
-        @Override
-        public List<UUID> getDescriptors() {
-            final List<UUID> identifiers = new ArrayList<>();
-            for (final BluetoothGattDescriptor descriptor : nativeCharacteristic.getDescriptors()) {
-                identifiers.add(descriptor.getUuid());
-            }
-            return identifiers;
-        }
-
-        @Permissions
-        @Override
-        public int getDescriptorPermissions(@NonNull UUID identifier) {
-            final BluetoothGattDescriptor descriptor = nativeCharacteristic.getDescriptor(identifier);
-            if (descriptor != null) {
-                final @Permissions int permissions = descriptor.getPermissions();
-                return permissions;
-            } else {
-                return PERMISSION_NULL;
-            }
-        }
-
-        @NonNull
-        @Override
-        public Observable<UUID> enableNotification(@NonNull UUID descriptor,
-                                                   @NonNull OperationTimeout timeout) {
-            // TODO: Re-implement this operation in terms of new API.
-
-            return peripheral.enableNotification(getService(),
-                                                 getUuid(),
-                                                 descriptor,
-                                                 timeout);
-        }
-
-        @NonNull
-        @Override
-        public Observable<UUID> disableNotification(@NonNull UUID descriptor,
-                                                    @NonNull OperationTimeout timeout) {
-            // TODO: Re-implement this operation in terms of new API.
-
-            return peripheral.disableNotification(getService(),
-                                                  getUuid(),
-                                                  descriptor,
-                                                  timeout);
-        }
-
-        @NonNull
-        @Override
-        public Observable<Void> write(@NonNull GattPeripheral.WriteType writeType,
-                                      @NonNull byte[] payload,
-                                      @NonNull OperationTimeout timeout) {
-            // TODO: Re-implement this operation in terms of new API.
-
-            return peripheral.writeCommand(getService(),
-                                           getUuid(),
-                                           writeType,
-                                           payload,
-                                           timeout);
-        }
-
-        @Override
-        public String toString() {
-            return "NativeCharacteristic{" +
-                    "uuid=" + getUuid() +
-                    '}';
-        }
     }
 }

--- a/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/android/NativeGattService.java
+++ b/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/android/NativeGattService.java
@@ -29,7 +29,7 @@ import is.hello.buruberi.bluetooth.stacks.GattCharacteristic;
 import is.hello.buruberi.bluetooth.stacks.GattService;
 
 public final class NativeGattService implements GattService {
-    final BluetoothGattService service;
+    final BluetoothGattService wrappedService;
     private final NativeGattPeripheral peripheral;
     private final Map<UUID, NativeGattCharacteristic> characteristics = new HashMap<>();
 
@@ -46,29 +46,29 @@ public final class NativeGattService implements GattService {
         return peripheralServices;
     }
 
-    NativeGattService(@NonNull BluetoothGattService service,
+    NativeGattService(@NonNull BluetoothGattService wrappedService,
                       @NonNull NativeGattPeripheral peripheral) {
-        this.service = service;
+        this.wrappedService = wrappedService;
         this.peripheral = peripheral;
     }
 
 
     @Override
     public UUID getUuid() {
-        return service.getUuid();
+        return wrappedService.getUuid();
     }
 
     @Override
     @Type
     public int getType() {
-        final @Type int type = service.getType();
+        final @Type int type = wrappedService.getType();
         return type;
     }
 
     @Override
     public List<UUID> getCharacteristics() {
         final List<UUID> identifiers = new ArrayList<>();
-        for (final BluetoothGattCharacteristic characteristic : service.getCharacteristics()) {
+        for (final BluetoothGattCharacteristic characteristic : wrappedService.getCharacteristics()) {
             identifiers.add(characteristic.getUuid());
         }
         return identifiers;
@@ -78,7 +78,7 @@ public final class NativeGattService implements GattService {
     public GattCharacteristic getCharacteristic(@NonNull UUID identifier) {
         NativeGattCharacteristic nativeCharacteristic = characteristics.get(identifier);
         if (nativeCharacteristic == null) {
-            final BluetoothGattCharacteristic characteristic = service.getCharacteristic(identifier);
+            final BluetoothGattCharacteristic characteristic = wrappedService.getCharacteristic(identifier);
             if (characteristic != null) {
                 nativeCharacteristic = new NativeGattCharacteristic(characteristic, this, peripheral);
                 characteristics.put(identifier, nativeCharacteristic);
@@ -94,19 +94,19 @@ public final class NativeGattService implements GattService {
         if (o == null || getClass() != o.getClass()) return false;
 
         final NativeGattService that = (NativeGattService) o;
-        return service.equals(that.service);
+        return wrappedService.equals(that.wrappedService);
     }
 
     @Override
     public int hashCode() {
-        return service.hashCode();
+        return wrappedService.hashCode();
     }
 
 
     @Override
     public String toString() {
         return "AndroidPeripheralService{" +
-                "service=" + service +
+                "service=" + wrappedService +
                 '}';
     }
 }

--- a/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/noop/NoOpBluetoothStack.java
+++ b/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/noop/NoOpBluetoothStack.java
@@ -18,7 +18,6 @@ package is.hello.buruberi.bluetooth.stacks.noop;
 import android.annotation.TargetApi;
 import android.os.Build;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 import java.util.Collections;
 import java.util.List;
@@ -86,11 +85,6 @@ public class NoOpBluetoothStack implements BluetoothStack {
     @Override
     public Observable<Void> turnOff() {
         return Observable.error(new ChangePowerStateException());
-    }
-
-    @Override
-    public boolean errorRequiresReconnect(@Nullable Throwable e) {
-        return false;
     }
 
     @NonNull

--- a/buruberi-core/src/test/java/is/hello/buruberi/bluetooth/stacks/android/NativeGattPeripheralTests.java
+++ b/buruberi-core/src/test/java/is/hello/buruberi/bluetooth/stacks/android/NativeGattPeripheralTests.java
@@ -65,6 +65,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -812,7 +813,7 @@ public class NativeGattPeripheralTests extends BuruberiTestCase {
         final ShadowBluetoothGatt gattShadow = BuruberiShadows.shadowOf(gatt);
         gattShadow.verifyCall(ShadowBluetoothGatt.Call.WRITE_CHAR,
                               Matchers.any(BluetoothGattCharacteristic.class));
-        verify(nativeService).getCharacteristic(Testing.WRITE_CHARACTERISTIC);
+        verify(nativeService, atLeastOnce()).getCharacteristic(Testing.WRITE_CHARACTERISTIC);
         verify(timeout).setTimeoutAction(Mockito.any(Action0.class), Mockito.any(Scheduler.class));
         verify(timeout).schedule();
 
@@ -846,7 +847,7 @@ public class NativeGattPeripheralTests extends BuruberiTestCase {
         final ShadowBluetoothGatt gattShadow = BuruberiShadows.shadowOf(gatt);
         gattShadow.verifyCall(ShadowBluetoothGatt.Call.WRITE_CHAR,
                               Matchers.any(BluetoothGattCharacteristic.class));
-        verify(nativeService).getCharacteristic(Testing.WRITE_CHARACTERISTIC);
+        verify(nativeService, atLeastOnce()).getCharacteristic(Testing.WRITE_CHARACTERISTIC);
         verify(timeout).setTimeoutAction(Mockito.any(Action0.class), Mockito.any(Scheduler.class));
         verify(timeout).schedule();
 
@@ -881,7 +882,7 @@ public class NativeGattPeripheralTests extends BuruberiTestCase {
         final ShadowBluetoothGatt gattShadow = BuruberiShadows.shadowOf(gatt);
         gattShadow.verifyCall(ShadowBluetoothGatt.Call.WRITE_CHAR,
                               Matchers.any(BluetoothGattCharacteristic.class));
-        verify(nativeService).getCharacteristic(Testing.WRITE_CHARACTERISTIC);
+        verify(nativeService, atLeastOnce()).getCharacteristic(Testing.WRITE_CHARACTERISTIC);
         verify(timeout).setTimeoutAction(Mockito.any(Action0.class), Mockito.any(Scheduler.class));
         verify(timeout).schedule();
 

--- a/buruberi-example/buruberi-example.iml
+++ b/buruberi-example/buruberi-example.iml
@@ -67,28 +67,24 @@
       <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/coverage-instrumented-classes" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/debug" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dex" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dex-cache" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/appcompat-v7/23.1.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/cardview-v7/23.1.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/recyclerview-v7/23.1.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-v4/23.1.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jacoco" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/javaResources" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/libs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/lint" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/ndk" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/mockable-android-23.jar" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/pre-dexed" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/proguard" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/release" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/tmp" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
       <excludeFolder url="file://$MODULE_DIR$/build/reports" />
       <excludeFolder url="file://$MODULE_DIR$/build/test-results" />

--- a/buruberi-testing/buruberi-testing.iml
+++ b/buruberi-testing/buruberi-testing.iml
@@ -68,28 +68,16 @@
       <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/docs" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/annotations" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/coverage-instrumented-classes" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dex" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dex-cache" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jacoco" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/javaResources" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/libs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/lint" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/ndk" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/pre-dexed" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/proguard" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/mockable-android-23.jar" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
       <excludeFolder url="file://$MODULE_DIR$/build/libs" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
-      <excludeFolder url="file://$MODULE_DIR$/build/publications" />
       <excludeFolder url="file://$MODULE_DIR$/build/reports" />
       <excludeFolder url="file://$MODULE_DIR$/build/test-results" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
@@ -102,15 +90,15 @@
     <orderEntry type="library" exported="" name="accessibility-test-framework-1.0" level="project" />
     <orderEntry type="library" exported="" name="hamcrest-library-1.3" level="project" />
     <orderEntry type="library" exported="" name="robolectric-resources-3.0" level="project" />
+    <orderEntry type="library" exported="" name="asm-commons-5.0.1" level="project" />
     <orderEntry type="library" exported="" name="ant-launcher-1.8.0" level="project" />
     <orderEntry type="library" exported="" name="robolectric-annotations-3.0" level="project" />
-    <orderEntry type="library" exported="" name="asm-commons-5.0.1" level="project" />
     <orderEntry type="library" exported="" name="asm-tree-5.0.1" level="project" />
     <orderEntry type="library" exported="" name="sqlite4java-0.282" level="project" />
     <orderEntry type="library" exported="" name="asm-5.0.1" level="project" />
     <orderEntry type="library" exported="" name="shadows-core-3.0" level="project" />
-    <orderEntry type="library" exported="" name="asm-analysis-5.0.1" level="project" />
     <orderEntry type="library" exported="" name="robolectric-utils-3.0" level="project" />
+    <orderEntry type="library" exported="" name="asm-analysis-5.0.1" level="project" />
     <orderEntry type="library" exported="" name="hamcrest-core-1.3" level="project" />
     <orderEntry type="library" exported="" name="vtd-xml-2.11" level="project" />
     <orderEntry type="library" exported="" name="junit-4.8.2" level="project" />


### PR DESCRIPTION
Moves the implementation of the characteristic interaction methods out of `GattNativePeripheral` into `GattNativeCharacteristic`. This is primarily to make the internal implementation reflect the latest supported interfaces. Also cleans up some of the internal implementation of the native stack in the process.

---

PR also contains a breaking change that removes the `BluetoothStack#errorRequiresReconnect(Throwable)` method as it was unused in all of Hello's internal codebases.