### PR TITLE
Miscellaneous backwards compatible enhancements to Buruberi

### DIFF
--- a/.idea/dictionaries/km.xml
+++ b/.idea/dictionaries/km.xml
@@ -8,6 +8,7 @@
       <w>peripheral's</w>
       <w>presenter's</w>
       <w>samsung</w>
+      <w>unparcel</w>
     </words>
   </dictionary>
 </component>

--- a/buruberi-core/build.gradle
+++ b/buruberi-core/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 // Used for both the 'aar' file and publish.
-def VERSION_NAME = '1.0.1'
+def VERSION_NAME = '1.0.2'
 def GROUP_ID = 'is.hello'
 def NAME = 'buruberi-core'
 def DESCRIPTION = 'Less flaky Bluetooth Low Energy for Android'

--- a/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/BluetoothStack.java
+++ b/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/BluetoothStack.java
@@ -40,6 +40,16 @@ public interface BluetoothStack {
      */
     String LOG_TAG = "Bluetooth." + BluetoothStack.class.getSimpleName();
 
+    /**
+     * A local broadcast that indicates an implicit pairing request has been initiated by the system.
+     * <p>
+     * Only available starting in API level 19, Android KitKat.
+     *
+     * @see GattPeripheral#EXTRA_NAME for the name of the affected peripheral.
+     * @see GattPeripheral#EXTRA_ADDRESS for the address of the affected peripheral.
+     */
+    String ACTION_PAIRING_REQUEST = BluetoothStack.class.getName() + ".ACTION_PAIRING_REQUEST";
+
 
     /**
      * Performs a scan for peripherals matching a given set of criteria.

--- a/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/BluetoothStack.java
+++ b/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/BluetoothStack.java
@@ -16,7 +16,9 @@
 package is.hello.buruberi.bluetooth.stacks;
 
 import android.Manifest;
+import android.os.Parcelable;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.annotation.RequiresPermission;
 
 import java.util.List;
@@ -121,4 +123,21 @@ public interface BluetoothStack {
      * Returns the logger facade associated with the {@code BluetoothStack}.
      */
     @NonNull LoggerFacade getLogger();
+
+
+    /**
+     * Writes the state of a peripheral into a {@code Parcelable} object.
+     *
+     * @param peripheral    The peripheral whose state needs to be saved.
+     * @return The saved state.
+     */
+    @Nullable Parcelable saveState(@NonNull GattPeripheral peripheral);
+
+    /**
+     * Restores the saved state of a peripheral into a new object.
+     *
+     * @param savedState    The state to restore.
+     * @return A new peripheral representing the saved state.
+     */
+    GattPeripheral restoreState(@Nullable Parcelable savedState);
 }

--- a/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/GattPeripheral.java
+++ b/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/GattPeripheral.java
@@ -63,6 +63,15 @@ public interface GattPeripheral extends Comparable<GattPeripheral> {
 
     /**
      * A local broadcast that informs interested listeners
+     * that a {@code GattPeripheral} has connected.
+     *
+     * @see #EXTRA_NAME
+     * @see #EXTRA_ADDRESS
+     */
+    String ACTION_CONNECTED = GattPeripheral.class.getName() + ".ACTION_CONNECTED";
+
+    /**
+     * A local broadcast that informs interested listeners
      * that a {@code GattPeripheral} has disconnected.
      *
      * @see #EXTRA_NAME
@@ -229,13 +238,14 @@ public interface GattPeripheral extends Comparable<GattPeripheral> {
     })
     @Retention(RetentionPolicy.SOURCE)
     @Documented
-    @IntDef(flag = true, value = {
-            CONNECT_FLAG_WAIT_AVAILABLE,
-            CONNECT_FLAG_TRANSPORT_AUTO,
-            CONNECT_FLAG_TRANSPORT_BREDR,
-            CONNECT_FLAG_TRANSPORT_LE,
-            CONNECT_FLAG_DEFAULTS,
-    })
+    @IntDef(flag = true,
+            value = {
+                    CONNECT_FLAG_WAIT_AVAILABLE,
+                    CONNECT_FLAG_TRANSPORT_AUTO,
+                    CONNECT_FLAG_TRANSPORT_BREDR,
+                    CONNECT_FLAG_TRANSPORT_LE,
+                    CONNECT_FLAG_DEFAULTS,
+            })
     @interface ConnectFlags {}
 
     //endregion

--- a/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/GattPeripheral.java
+++ b/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/GattPeripheral.java
@@ -19,9 +19,11 @@ import android.Manifest;
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothGattCharacteristic;
 import android.bluetooth.BluetoothProfile;
+import android.os.Parcelable;
 import android.support.annotation.CheckResult;
 import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.annotation.RequiresPermission;
 
 import java.lang.annotation.Documented;
@@ -272,6 +274,17 @@ public interface GattPeripheral extends Comparable<GattPeripheral> {
      */
     @CheckResult
     @NonNull BluetoothStack getStack();
+
+    /**
+     * Convenience method for saving the state of the peripheral. Functionally equivalent to:
+     * <pre>{@code
+     * final BluetoothStack stack = peripheral.getStack();
+     * final Parcelable savedState = stack.saveState(peripheral);
+     * // ...
+     * }</pre>
+     * @return The saved state of the peripheral.
+     */
+    @Nullable Parcelable saveState();
 
     //endregion
 

--- a/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/GattPeripheral.java
+++ b/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/GattPeripheral.java
@@ -46,8 +46,11 @@ import rx.Observable;
  * All Observable objects returned by a GattPeripheral must be subscribed
  * to before they will perform their work. No guarantees are made about
  * what scheduler the Observables will do, and yield their work on.
+ * <p>
+ * {@code GattPeripheral} objects are ordered based on the strength of their RSSI at scan time.
+ * The {@code GattPeripheral} with the strongest signal in a collection will be placed last.
  */
-public interface GattPeripheral {
+public interface GattPeripheral extends Comparable<GattPeripheral> {
     /**
      * The log tag used by implementations of the GattPeripheral interface.
      */

--- a/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/android/NativeGattPeripheral.java
+++ b/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/android/NativeGattPeripheral.java
@@ -141,6 +141,13 @@ public class NativeGattPeripheral implements GattPeripheral,
         return stack;
     }
 
+    @Override
+    public int compareTo(@NonNull GattPeripheral other) {
+        final int myRssi = getScanTimeRssi();
+        final int otherRssi = other.getScanTimeRssi();
+        return (myRssi < otherRssi) ? -1 : ((myRssi > otherRssi) ? 1 : 0);
+    }
+
     //endregion
 
 

--- a/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/android/NativeGattPeripheral.java
+++ b/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/android/NativeGattPeripheral.java
@@ -283,6 +283,12 @@ public class NativeGattPeripheral implements GattPeripheral,
                         subscriber.onNext(NativeGattPeripheral.this);
                         subscriber.onCompleted();
 
+                        final Intent connectedIntent = new Intent(ACTION_CONNECTED)
+                                .putExtra(EXTRA_NAME, getName())
+                                .putExtra(EXTRA_ADDRESS, getAddress());
+                        LocalBroadcastManager.getInstance(stack.applicationContext)
+                                             .sendBroadcast(connectedIntent);
+
                         return false;
                     }
 
@@ -804,11 +810,11 @@ public class NativeGattPeripheral implements GattPeripheral,
             handleGattDisconnect(gatt);
 
             if (enabled) {
-                final Intent disconnect = new Intent(ACTION_DISCONNECTED);
-                disconnect.putExtra(EXTRA_NAME, getName());
-                disconnect.putExtra(EXTRA_ADDRESS, getAddress());
+                final Intent disconnectIntent = new Intent(ACTION_DISCONNECTED)
+                        .putExtra(EXTRA_NAME, getName())
+                        .putExtra(EXTRA_ADDRESS, getAddress());
                 LocalBroadcastManager.getInstance(stack.applicationContext)
-                                     .sendBroadcast(disconnect);
+                                     .sendBroadcast(disconnectIntent);
             }
         }
 

--- a/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/android/NativeGattPeripheral.java
+++ b/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/android/NativeGattPeripheral.java
@@ -25,6 +25,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.RequiresPermission;
@@ -74,7 +75,7 @@ public class NativeGattPeripheral implements GattPeripheral,
     private final @NonNull LoggerFacade logger;
     private final SerialQueue serialQueue;
 
-    @VisibleForTesting final @NonNull BluetoothDevice bluetoothDevice;
+    /*package*/ final @NonNull BluetoothDevice bluetoothDevice;
     private final int scannedRssi;
     private final @NonNull AdvertisingData advertisingData;
 
@@ -146,6 +147,12 @@ public class NativeGattPeripheral implements GattPeripheral,
         final int myRssi = getScanTimeRssi();
         final int otherRssi = other.getScanTimeRssi();
         return (myRssi < otherRssi) ? -1 : ((myRssi > otherRssi) ? 1 : 0);
+    }
+
+    @Nullable
+    @Override
+    public Parcelable saveState() {
+        return stack.saveState(this);
     }
 
     //endregion

--- a/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/android/NativeGattPeripheral.java
+++ b/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/android/NativeGattPeripheral.java
@@ -806,6 +806,24 @@ public class NativeGattPeripheral implements GattPeripheral,
         }
 
         @Override
+        /*package*/ boolean onConnected(@NonNull BluetoothGatt gatt, int status) {
+            // Do nothing, prevent this listener from being removed.
+            return true;
+        }
+
+        @Override
+        /*package*/ boolean onConnecting(@NonNull BluetoothGatt gatt, int status) {
+            // Do nothing, prevent this listener from being removed.
+            return true;
+        }
+
+        @Override
+        /*package*/ boolean onDisconnecting(@NonNull BluetoothGatt gatt, int status) {
+            // Do nothing, prevent this listener from being removed.
+            return true;
+        }
+
+        @Override
         /*package*/ boolean onDisconnected(@NonNull BluetoothGatt gatt, int status) {
             broadcast();
             return true;

--- a/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/noop/NoOpBluetoothStack.java
+++ b/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/noop/NoOpBluetoothStack.java
@@ -17,7 +17,9 @@ package is.hello.buruberi.bluetooth.stacks.noop;
 
 import android.annotation.TargetApi;
 import android.os.Build;
+import android.os.Parcelable;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import java.util.Collections;
 import java.util.List;
@@ -93,4 +95,14 @@ public class NoOpBluetoothStack implements BluetoothStack {
         return logger;
     }
 
+    @Nullable
+    @Override
+    public Parcelable saveState(@NonNull GattPeripheral peripheral) {
+        return null;
+    }
+
+    @Override
+    public GattPeripheral restoreState(@Nullable Parcelable savedState) {
+        return null;
+    }
 }

--- a/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/util/AdvertisingData.java
+++ b/buruberi-core/src/main/java/is/hello/buruberi/bluetooth/stacks/util/AdvertisingData.java
@@ -17,15 +17,14 @@ package is.hello.buruberi.bluetooth.stacks.util;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.util.SparseArray;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
 import rx.functions.Func1;
 
@@ -34,7 +33,7 @@ import rx.functions.Func1;
  * by predicates contained in a {@link PeripheralCriteria} instance.
  */
 public final class AdvertisingData {
-    private final Map<Integer, List<byte[]>> records = new HashMap<>();
+    private final SparseArray<List<byte[]>> records = new SparseArray<>();
 
     //region Creation
 
@@ -85,14 +84,18 @@ public final class AdvertisingData {
      * Returns whether or not there are no advertising data records.
      */
     public boolean isEmpty() {
-        return records.isEmpty();
+        return (records.size() == 0);
     }
 
     /**
      * Returns a sorted copy of the record types contained in the advertising data.
      */
     public List<Integer> copyRecordTypes() {
-        final List<Integer> recordTypes = new ArrayList<>(records.keySet());
+        final int count = records.size();
+        final List<Integer> recordTypes = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            recordTypes.add(records.keyAt(i));
+        }
         Collections.sort(recordTypes);
         return recordTypes;
     }
@@ -145,13 +148,10 @@ public final class AdvertisingData {
     @Override
     public String toString() {
         String string = "{";
-        final Iterator<Map.Entry<Integer, List<byte[]>>> recordIterator =
-                records.entrySet().iterator();
-        while (recordIterator.hasNext()) {
-            final Map.Entry<Integer, List<byte[]>> entry = recordIterator.next();
-            string += typeToString(entry.getKey());
+        for (int i = 0, count = records.size(); i < count; i++) {
+            string += typeToString(records.keyAt(i));
             string += "=[";
-            final Iterator<byte[]> entryIterator = entry.getValue().iterator();
+            final Iterator<byte[]> entryIterator = records.valueAt(i).iterator();
             while (entryIterator.hasNext()) {
                 byte[] contents = entryIterator.next();
                 string += Bytes.toString(contents);
@@ -159,7 +159,7 @@ public final class AdvertisingData {
                     string += ", ";
                 }
             }
-            if (recordIterator.hasNext()) {
+            if (i < count - 1) {
                 string += "], ";
             } else {
                 string += "]";

--- a/buruberi-core/src/main/java/is/hello/buruberi/util/SerialQueue.java
+++ b/buruberi-core/src/main/java/is/hello/buruberi/util/SerialQueue.java
@@ -23,13 +23,21 @@ import android.util.Log;
 import java.util.LinkedList;
 import java.util.Queue;
 
-
+/**
+ * A serial task queue that decouples the start and completion of execution of a task
+ * to allow serialization of tasks with asynchronous starts and finishes.
+ */
 public final class SerialQueue {
     private final String LOG_TAG = SerialQueue.class.getSimpleName();
 
     @VisibleForTesting final Queue<Task> queue = new LinkedList<>();
     @VisibleForTesting boolean busy = false;
 
+    /**
+     * Submit a task for execution into the queue. If the queue is currently empty,
+     * the task will be synchronously run immediately.
+     * @param task  The task to execute.
+     */
     public void execute(@NonNull Task task) {
         Log.d(LOG_TAG, "execute(" + task + ") [busy: " + busy + "]");
         queue.offer(task);
@@ -51,18 +59,17 @@ public final class SerialQueue {
                 task.run();
             } catch (Throwable e) {
                 Log.d(LOG_TAG, "-- error clean up " + e + " --");
-
-                Task enqueuedTask;
-                while ((enqueuedTask = queue.poll()) != null) {
-                    enqueuedTask.cancel(e);
-                }
-                this.busy = false;
-
+                cancelPending(e);
                 throw e;
             }
         }
     }
 
+    /**
+     * Informs the queue that the currently executing task has completed,
+     * and the next task in the queue should be run. If there is another
+     * task in the queue, it will immediately be run.
+     */
     public void taskDone() {
         Log.d(LOG_TAG, "taskDone()");
 
@@ -75,8 +82,42 @@ public final class SerialQueue {
         }
     }
 
+    /**
+     * Cancels any pending tasks in the queue, passing an optional cause object to them.
+     * @param cause The cause of the queue cancellation.
+     */
+    public void cancelPending(@Nullable Throwable cause) {
+        Log.d(LOG_TAG, "cancelPending()");
 
+        Task enqueuedTask;
+        while ((enqueuedTask = queue.poll()) != null) {
+            enqueuedTask.cancel(cause);
+        }
+        this.busy = false;
+    }
+
+    /**
+     * Cancels any pending tasks in the queue.
+     */
+    public void cancelPending() {
+        cancelPending(null);
+    }
+
+
+    /**
+     * A single unit of work to run inside of a {@link SerialQueue}.
+     * <p>
+     * When a {@code Task} has completed its work, it must call {@link SerialQueue#taskDone()}.
+     * <p>
+     * If the {@link #run()} method of the {@code Task} throws an exception,
+     * the exception will be logged, and any pending tasks in the serial queue
+     * will be immediately canceled.
+     */
     public interface Task extends Runnable {
+        /**
+         * Informs the task it has been canceled before it could be run.
+         * @param cause The cause of the cancellation.
+         */
         void cancel(@Nullable Throwable cause);
     }
 }

--- a/buruberi-core/src/test/java/is/hello/buruberi/bluetooth/stacks/android/NativeBluetoothStackTests.java
+++ b/buruberi-core/src/test/java/is/hello/buruberi/bluetooth/stacks/android/NativeBluetoothStackTests.java
@@ -258,6 +258,7 @@ public class NativeBluetoothStackTests extends BuruberiTestCase {
         final NativeBluetoothStack stack = new NativeBluetoothStack(getContext(),
                                                                     errorListener,
                                                                     loggerFacade);
+        getShadowBluetoothAdapter();
         final BluetoothDevice bluetoothDevice = createMockDevice(DEVICE_ADDRESS);
         final AdvertisingData advertisingData = new AdvertisingDataBuilder()
                 .add(TYPE_LIST_OF_16_BIT_SERVICE_CLASS_UUIDS, "E1FE")

--- a/buruberi-core/src/test/java/is/hello/buruberi/bluetooth/stacks/android/NativeBluetoothStackTests.java
+++ b/buruberi-core/src/test/java/is/hello/buruberi/bluetooth/stacks/android/NativeBluetoothStackTests.java
@@ -17,26 +17,37 @@ package is.hello.buruberi.bluetooth.stacks.android;
 
 import android.annotation.TargetApi;
 import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothDevice;
 import android.content.Intent;
 import android.os.Build;
+import android.os.Parcelable;
 
 import org.junit.Test;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowBluetoothAdapter;
 
 import is.hello.buruberi.bluetooth.errors.ChangePowerStateException;
+import is.hello.buruberi.bluetooth.stacks.GattPeripheral;
+import is.hello.buruberi.bluetooth.stacks.util.AdvertisingData;
 import is.hello.buruberi.bluetooth.stacks.util.ErrorListener;
 import is.hello.buruberi.bluetooth.stacks.util.LoggerFacade;
 import is.hello.buruberi.bluetooth.stacks.util.PeripheralCriteria;
 import is.hello.buruberi.testing.BuruberiTestCase;
 import is.hello.buruberi.testing.Sync;
+import is.hello.buruberi.util.AdvertisingDataBuilder;
 import is.hello.buruberi.util.Defaults;
 import rx.Observable;
 
+import static is.hello.buruberi.bluetooth.stacks.util.AdvertisingData.TYPE_LIST_OF_16_BIT_SERVICE_CLASS_UUIDS;
+import static is.hello.buruberi.testing.Testing.DEVICE_ADDRESS;
+import static is.hello.buruberi.testing.Testing.createMockDevice;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class NativeBluetoothStackTests extends BuruberiTestCase {
     private final ErrorListener errorListener = Defaults.createEmptyErrorListener();
@@ -215,5 +226,56 @@ public class NativeBluetoothStackTests extends BuruberiTestCase {
 
         Sync.wrap(turnOff)
             .assertThrows(ChangePowerStateException.class);
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void saveStateSafety() {
+        final NativeBluetoothStack stack = new NativeBluetoothStack(getContext(),
+                                                                    errorListener,
+                                                                    loggerFacade);
+        stack.saveState(mock(GattPeripheral.class));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void restoreStateSafety() {
+        final NativeBluetoothStack stack = new NativeBluetoothStack(getContext(),
+                                                                    errorListener,
+                                                                    loggerFacade);
+        stack.restoreState(new Intent());
+    }
+
+    @Test
+    public void restoreStateNullSafety() {
+        final NativeBluetoothStack stack = new NativeBluetoothStack(getContext(),
+                                                                    errorListener,
+                                                                    loggerFacade);
+        assertThat(stack.restoreState(null), is(nullValue()));
+    }
+
+    @Test
+    public void saveRestoreState() {
+        final NativeBluetoothStack stack = new NativeBluetoothStack(getContext(),
+                                                                    errorListener,
+                                                                    loggerFacade);
+        final BluetoothDevice bluetoothDevice = createMockDevice(DEVICE_ADDRESS);
+        final AdvertisingData advertisingData = new AdvertisingDataBuilder()
+                .add(TYPE_LIST_OF_16_BIT_SERVICE_CLASS_UUIDS, "E1FE")
+                .build();
+        final int rssi = -50;
+
+        final GattPeripheral outPeripheral = new NativeGattPeripheral(stack, bluetoothDevice,
+                                                                      rssi, advertisingData);
+        assertThat(outPeripheral.getAddress(), is(equalTo(DEVICE_ADDRESS)));
+
+        final Parcelable outState = stack.saveState(outPeripheral);
+        assertThat(outState, is(notNullValue()));
+
+        final GattPeripheral inPeripheral = stack.restoreState(outState);
+        assertThat(inPeripheral, is(notNullValue()));
+        assertThat(inPeripheral.getScanTimeRssi(), is(equalTo(rssi)));
+        assertThat(inPeripheral.getAddress(), is(equalTo(outPeripheral.getAddress())));
+        assertThat(inPeripheral.getAdvertisingData().isEmpty(),
+                   is(equalTo(outPeripheral.getAdvertisingData().isEmpty())));
     }
 }

--- a/buruberi-core/src/test/java/is/hello/buruberi/bluetooth/stacks/android/NativeGattPeripheralTests.java
+++ b/buruberi-core/src/test/java/is/hello/buruberi/bluetooth/stacks/android/NativeGattPeripheralTests.java
@@ -31,8 +31,10 @@ import android.support.v4.content.LocalBroadcastManager;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -65,6 +67,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -96,6 +99,32 @@ public class NativeGattPeripheralTests extends BuruberiTestCase {
         peripheral.gatt = device.connectGatt(getContext(), false, peripheral.gattDispatcher);
         return peripheral;
     }
+
+
+    //region Ordering
+
+    @Test
+    public void compareTo() {
+        final NativeGattPeripheral peripheral1 = mock(NativeGattPeripheral.class, CALLS_REAL_METHODS);
+        doReturn(-90).when(peripheral1).getScanTimeRssi();
+
+        final NativeGattPeripheral peripheral2 = mock(NativeGattPeripheral.class, CALLS_REAL_METHODS);
+        doReturn(0).when(peripheral2).getScanTimeRssi();
+
+        final NativeGattPeripheral peripheral3 = mock(NativeGattPeripheral.class, CALLS_REAL_METHODS);
+        doReturn(-120).when(peripheral3).getScanTimeRssi();
+
+        final List<NativeGattPeripheral> peripherals = Arrays.asList(peripheral1,
+                                                                     peripheral2,
+                                                                     peripheral3);
+        Collections.sort(peripherals);
+
+        assertThat(peripherals.get(0), is(equalTo(peripheral3)));
+        assertThat(peripherals.get(1), is(equalTo(peripheral1)));
+        assertThat(peripherals.get(2), is(equalTo(peripheral2)));
+    }
+
+    //endregion
 
 
     //region Connectivity

--- a/buruberi-core/src/test/java/is/hello/buruberi/bluetooth/stacks/util/AdvertisingDataTests.java
+++ b/buruberi-core/src/test/java/is/hello/buruberi/bluetooth/stacks/util/AdvertisingDataTests.java
@@ -19,11 +19,13 @@ import org.junit.Test;
 
 import java.util.Collection;
 
+import is.hello.buruberi.testing.BuruberiTestCase;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
-public class AdvertisingDataTests {
+public class AdvertisingDataTests extends BuruberiTestCase {
     private static final byte[] TEST_PAYLOAD = {
             // Advertisement contents size
             (byte) 0x03,
@@ -39,10 +41,10 @@ public class AdvertisingDataTests {
     @SuppressWarnings("ConstantConditions")
     @Test
     public void parse() throws Exception {
-        AdvertisingData advertisingData = AdvertisingData.parse(TEST_PAYLOAD);
+        final AdvertisingData advertisingData = AdvertisingData.parse(TEST_PAYLOAD);
         assertFalse(advertisingData.isEmpty());
 
-        Collection<byte[]> records = advertisingData.getRecordsForType(AdvertisingData.TYPE_LIST_OF_16_BIT_SERVICE_CLASS_UUIDS);
+        final Collection<byte[]> records = advertisingData.getRecordsForType(AdvertisingData.TYPE_LIST_OF_16_BIT_SERVICE_CLASS_UUIDS);
         assertNotNull(records);
         assertFalse(records.isEmpty());
         assertEquals(Bytes.toString(records.iterator().next()), "E1FE");

--- a/buruberi-core/src/test/java/is/hello/buruberi/bluetooth/stacks/util/AdvertisingDataTests.java
+++ b/buruberi-core/src/test/java/is/hello/buruberi/bluetooth/stacks/util/AdvertisingDataTests.java
@@ -15,15 +15,25 @@
 */
 package is.hello.buruberi.bluetooth.stacks.util;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 import is.hello.buruberi.testing.BuruberiTestCase;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+import static is.hello.buruberi.bluetooth.stacks.util.AdvertisingData.TYPE_LIST_OF_16_BIT_SERVICE_CLASS_UUIDS;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
 
 public class AdvertisingDataTests extends BuruberiTestCase {
     private static final byte[] TEST_PAYLOAD = {
@@ -31,7 +41,7 @@ public class AdvertisingDataTests extends BuruberiTestCase {
             (byte) 0x03,
 
             // Advertisement data type
-            (byte) AdvertisingData.TYPE_LIST_OF_16_BIT_SERVICE_CLASS_UUIDS,
+            (byte) TYPE_LIST_OF_16_BIT_SERVICE_CLASS_UUIDS,
 
             // Begin data
             (byte) 0xE1,
@@ -40,13 +50,73 @@ public class AdvertisingDataTests extends BuruberiTestCase {
 
     @SuppressWarnings("ConstantConditions")
     @Test
-    public void parse() throws Exception {
+    public void parse() {
         final AdvertisingData advertisingData = AdvertisingData.parse(TEST_PAYLOAD);
-        assertFalse(advertisingData.isEmpty());
+        assertThat(advertisingData.isEmpty(), is(false));
 
-        final Collection<byte[]> records = advertisingData.getRecordsForType(AdvertisingData.TYPE_LIST_OF_16_BIT_SERVICE_CLASS_UUIDS);
-        assertNotNull(records);
-        assertFalse(records.isEmpty());
-        assertEquals(Bytes.toString(records.iterator().next()), "E1FE");
+        final Collection<byte[]> records =
+                advertisingData.getRecordsForType(TYPE_LIST_OF_16_BIT_SERVICE_CLASS_UUIDS);
+        assertThat(records, is(notNullValue()));
+        assertThat(records.isEmpty(), is(false));
+        assertThat(Bytes.toString(records.iterator().next()), is(equalTo("E1FE")));
     }
+
+    @Test
+    public void parceling() {
+        final AdvertisingData outData = AdvertisingData.parse(TEST_PAYLOAD);
+        assertThat(outData.isEmpty(), is(false));
+
+        final AdvertisingData inData = parcelUnparcel(outData);
+        assertThat(inData.isEmpty(), is(false));
+        assertThat(asArray(inData.getRecordsForType(TYPE_LIST_OF_16_BIT_SERVICE_CLASS_UUIDS)),
+                   is(deepEqualTo(asArray(outData.getRecordsForType(TYPE_LIST_OF_16_BIT_SERVICE_CLASS_UUIDS)))));
+    }
+
+
+    //region Utilities
+
+    private static <T extends Parcelable> T parcelUnparcel(T out) {
+        final Parcel outParcel = Parcel.obtain();
+        final byte[] marshaled;
+        try {
+            outParcel.writeParcelable(out, 0);
+            marshaled = outParcel.marshall();
+        } finally {
+            outParcel.recycle();
+        }
+
+        final Parcel inParcel = Parcel.obtain();
+        try {
+            inParcel.unmarshall(marshaled, 0, marshaled.length);
+            return inParcel.readParcelable(out.getClass().getClassLoader());
+        } finally {
+            inParcel.recycle();
+        }
+    }
+
+    private static byte[][] asArray(List<byte[]> entries) {
+        if (entries == null || entries.isEmpty()) {
+            return new byte[0][];
+        } else {
+            return entries.toArray(new byte[entries.size()][]);
+        }
+    }
+
+    private static Matcher<Object[]> deepEqualTo(final Object[] right) {
+        return new BaseMatcher<Object[]>() {
+            @Override
+            public boolean matches(Object item) {
+                return (item.getClass().isArray() &&
+                        Arrays.deepEquals((Object[]) item, right));
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("deep equals ");
+                description.appendValue(right);
+            }
+        };
+    }
+
+    //endregion
 }

--- a/buruberi-core/src/test/java/is/hello/buruberi/testing/Testing.java
+++ b/buruberi-core/src/test/java/is/hello/buruberi/testing/Testing.java
@@ -36,8 +36,6 @@ import java.util.concurrent.TimeUnit;
 
 import is.hello.buruberi.bluetooth.stacks.OperationTimeout;
 import is.hello.buruberi.bluetooth.stacks.util.AdvertisingData;
-import is.hello.buruberi.testing.BuruberiShadows;
-import is.hello.buruberi.testing.ShadowBluetoothDeviceExt;
 import is.hello.buruberi.util.AdvertisingDataBuilder;
 import rx.Scheduler;
 import rx.Subscriber;


### PR DESCRIPTION
Changes include...
- Bumped library version to `1.0.2`
- `GattPeripheral` instances now support ordering based on their scan time RSSI (`implements Comparable<GattPeripheral>`)
- Added new local broadcast for system level pairing requests (KitKat+, reliable on Marshmallow+ only)
- Added new local broadcast for successful connections to peripherals
- Added `#cancelPending()` method to `SerialQueue` to allow for better client error handling
- Added support for parceling `GattPeripheral` objects for cleaner client code
- Added support for parceling `AdvertisingData`, and switched to more efficient backing store
- Fixed a bug where `ACTION_DISCONNECTED` would sometimes only broadcast once
- Minor improvements to unit tests
